### PR TITLE
Fix VLESS/VMESS Configurations for Request Host and Path in Xray and Sing-box

### DIFF
--- a/v2share/singbox.py
+++ b/v2share/singbox.py
@@ -93,7 +93,7 @@ class SingBoxConfig(BaseConfig):
 
     @staticmethod
     def transport_config(
-        transport_type="http",
+        transport_type="tcp",
         host=None,
         path=None,
         http_method=None,
@@ -104,10 +104,11 @@ class SingBoxConfig(BaseConfig):
 
         transport_config = {"type": transport_type}
 
-        if transport_type == "http":
+        if transport_type == "tcp":
+            transport_config["type"] = "http"
             transport_config["headers"] = headers
             if host:
-                transport_config["host"] = host
+                transport_config["host"] = [host]
             if path:
                 transport_config["path"] = path
             if http_method:
@@ -152,7 +153,7 @@ class SingBoxConfig(BaseConfig):
         ):
             outbound["flow"] = config.flow
 
-        if config.transport_type in ["http", "ws", "quic", "grpc", "httpupgrade"]:
+        if config.transport_type in ["tcp", "ws", "quic", "grpc", "httpupgrade"]:
             outbound["transport"] = SingBoxConfig.transport_config(
                 transport_type=config.transport_type,
                 host=config.host,

--- a/v2share/xray.py
+++ b/v2share/xray.py
@@ -204,8 +204,6 @@ class XrayConfig(BaseConfig):
     def tcp_http_config(header_type=None, host=None, path=None):
         if header_type is None:
             header_type = "none"
-        if host is None:
-            host = ""
         if path is None:
             path = "/"
 
@@ -218,7 +216,7 @@ class XrayConfig(BaseConfig):
         if header_type != "none":
             tcp_settings["header"]["request"] = {
                 "headers": {
-                    "Host": [host],
+                    "Host": [host] if host else [],
                 },
                 "path": [path],
             }

--- a/v2share/xray.py
+++ b/v2share/xray.py
@@ -205,21 +205,23 @@ class XrayConfig(BaseConfig):
         if header_type is None:
             header_type = "none"
         if host is None:
-            host = []
+            host = ""
         if path is None:
             path = "/"
 
         tcp_settings = {
             "header": {
                 "type": header_type,
-                "request": {
-                    "headers": {
-                        "Host": [host],
-                    },
-                    "path": [path],
-                },
-            },
+            }
         }
+
+        if header_type != "none":
+            tcp_settings["header"]["request"] = {
+                "headers": {
+                    "Host": [host],
+                },
+                "path": [path],
+            }
 
         return tcp_settings
 

--- a/v2share/xray.py
+++ b/v2share/xray.py
@@ -154,7 +154,6 @@ class XrayConfig(BaseConfig):
 
     @staticmethod
     def reality_config(public_key, short_id, sni, fingerprint="", spiderx=""):
-
         return {
             "serverName": sni,
             "fingerprint": fingerprint,
@@ -192,7 +191,6 @@ class XrayConfig(BaseConfig):
 
     @staticmethod
     def grpc_config(authority=None, service_name=None, multi_mode=False):
-
         grpc_settings = {
             "multiMode": multi_mode,
         }
@@ -203,14 +201,24 @@ class XrayConfig(BaseConfig):
         return grpc_settings
 
     @staticmethod
-    def tcp_http_config(header_type=None):
+    def tcp_http_config(header_type=None, host=None, path=None):
         if header_type is None:
             header_type = "none"
+        if host is None:
+            host = []
+        if path is None:
+            path = "/"
 
         tcp_settings = {
             "header": {
                 "type": header_type,
-            }
+                "request": {
+                    "headers": {
+                        "Host": [host],
+                    },
+                    "path": [path],
+                },
+            },
         }
 
         return tcp_settings
@@ -248,7 +256,6 @@ class XrayConfig(BaseConfig):
 
     @staticmethod
     def quic_config(security="none", key=None, header_type="none"):
-
         quic_settings = {
             "security": security,
             "header": {"type": header_type},
@@ -261,7 +268,6 @@ class XrayConfig(BaseConfig):
 
     @staticmethod
     def kcp_config(seed=None, header_type=None):
-
         kcp_settings = {
             "header": {},
         }
@@ -313,7 +319,7 @@ class XrayConfig(BaseConfig):
             )
         elif net == "tcp":
             stream_settings["tcpSettings"] = XrayConfig.tcp_http_config(
-                header_type=header_type
+                header_type=header_type, host=host, path=path
             )
         elif net == "quic":
             stream_settings["quicSettings"] = XrayConfig.quic_config(
@@ -348,7 +354,6 @@ class XrayConfig(BaseConfig):
 
     @staticmethod
     def vmess_config(address: str, port: int, uuid: str):
-
         return {
             "vnext": [
                 {
@@ -366,7 +371,6 @@ class XrayConfig(BaseConfig):
 
     @staticmethod
     def vless_config(address, port, uuid, flow=""):
-
         return {
             "vnext": [
                 {


### PR DESCRIPTION
This PR addresses an issue in the VLESS and VMESS configurations within both Xray and Sing-box where the requestHost and requestPath variables were not being set correctly. Previously, these variables were either missing or incorrectly assigned, causing issues with routing and request handling.


Please review and let me know if any further modifications are required.