### PR TITLE
fix mux key for singbox

### DIFF
--- a/v2share/singbox.py
+++ b/v2share/singbox.py
@@ -269,7 +269,7 @@ class SingBoxConfig(BaseConfig):
         }:
             outbound["multiplex"] = {"enabled": True}
             if config.mux_settings.sing_box_mux_settings is not None:
-                outbound["mux"] = filter_dict(
+                outbound["multiplex"] = filter_dict(
                     {
                         "max_connections": config.mux_settings.sing_box_mux_settings.max_connections,
                         "min_streams": config.mux_settings.sing_box_mux_settings.min_streams,

--- a/v2share/singbox.py
+++ b/v2share/singbox.py
@@ -267,7 +267,7 @@ class SingBoxConfig(BaseConfig):
             "yamux",
             "smux",
         }:
-            outbound["mux"] = {"enabled": True}
+            outbound["multiplex"] = {"enabled": True}
             if config.mux_settings.sing_box_mux_settings is not None:
                 outbound["mux"] = filter_dict(
                     {


### PR DESCRIPTION
The mux key in Singbox configurations is actually `multiplex`, not `mux`. You can see an example in [source](https://sing-box.sagernet.org/configuration/outbound/trojan/) for the accuracy of this issue.
**old version**:
```
{
  "type": "trojan",
  "tag": "trojan-out",

  "mux": {},
}
```
**new version**:
```
{
  "type": "trojan",
  "tag": "trojan-out",

  "multiplex": {},
}
```